### PR TITLE
fix(navbar): page contents were overlapping navbar

### DIFF
--- a/src/components/layout/Navbar.vue
+++ b/src/components/layout/Navbar.vue
@@ -76,6 +76,8 @@ export default Vue.component('Navbar', {
 header {
   margin: auto;
   text-align: left;
+  position: relative;
+  z-index: $z-header;
   height: 5em;
   display: flex;
   padding: 0 !important;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -2,6 +2,9 @@
 
 $dark-mode-class: 'dark-theme';
 
+//Z-index
+$z-header: 2;
+
 // Colors
 $text-primary: $nord3;
 $text-secondary: $nord6;


### PR DESCRIPTION
## Description

**Summary**

The page contents from the event and team page were overlapping the navbar when in mobile or tablet. 

## Changes

**What kind of change does this PR introduce?** (check at least one by adding an "x" between the brackets)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications: -

**Screenshots and videos**
![navbar-overlap-1](https://user-images.githubusercontent.com/87768087/216564956-0d852984-60fc-44b6-b12b-da4c62b5fa32.png)
![navbar-overlap-2](https://user-images.githubusercontent.com/87768087/216564969-cd6f028e-c6fb-47b4-a047-7e2dd18dce23.png)

**The PR fulfills these requirements:**

- [X] Schrödinger Hat [code of conduct](https://www.schrodinger-hat.it/code-of-conduct)