### PR TITLE
refactor(MobileMenu & TheNavbar): convert to UnoCSS, reduce boilerplate

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev": "vite --host",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "lint:scss": "stylelint \"./**/*.{css,scss,sass,vue}\"",
     "serve": "vite preview",
     "test": "vitest",
     "coverage": "vitest run --coverage",

--- a/src/App.vue
+++ b/src/App.vue
@@ -67,7 +67,7 @@ body {
   vertical-align: super;
 }
 
-//Animations
+// Animations
 
 @keyframes scale {
   0% {

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,10 +5,12 @@ import TheNavbar from '@/components/layout/TheNavbar.vue'
 </script>
 
 <template>
-  <TheNavbar />
-  <RouterView />
-  <TheContributing />
-  <TheFooter />
+  <div class="relative">
+    <TheNavbar />
+    <RouterView />
+    <TheContributing />
+    <TheFooter />
+  </div>
 </template>
 
 <style lang="scss">

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,7 @@ import TheNavbar from '@/components/layout/TheNavbar.vue'
 
 <template>
   <TheNavbar />
-  <router-view />
+  <RouterView />
   <TheContributing />
   <TheFooter />
 </template>

--- a/src/components/buttons/CtaIcon.vue
+++ b/src/components/buttons/CtaIcon.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { useAttrs } from 'vue'
+import { useCtaComponent } from '@/functions/useCtaComponent'
+
+defineProps<{
+  icon: string
+  small?: boolean
+}>()
+
+const { component, bindings } = useCtaComponent(useAttrs())
+</script>
+
+<template>
+  <component
+    :is="component"
+    v-bind="bindings"
+    class="button mx-1 px-1 py-0.5 rounded-1"
+    :class="{ small }"
+  >
+    <i :class="icon" />
+  </component>
+</template>
+
+<style lang="scss" scoped>
+.button {
+  font-size: rem(20px);
+
+  &.small {
+    font-size: rem(16px);
+  }
+}
+</style>

--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
+import { watch } from 'vue'
 import CtaComponent from '@/components/buttons/CtaComponent.vue'
 
 interface Link {
@@ -12,17 +13,22 @@ interface Link {
   icon?: string
 }
 
-defineProps<{
+const props = defineProps<{
   links: Link[]
   show: boolean
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   (e: 'close'): void
 }>()
 
 const breakpoints = useBreakpoints(breakpointsTailwind)
 const smallerThanLg = breakpoints.smaller('md')
+
+watch(smallerThanLg, (newIsSmaller) => {
+  if (props.show && newIsSmaller)
+    emit('close')
+})
 </script>
 
 <template>

--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -35,7 +35,7 @@ const smallerThanLg = breakpoints.smaller('md')
         :href="href"
         :target="target ? target : null"
         :to="to ? { name: to } : null"
-        class="head-6 link block py-4 cursor-pointer"
+        class="head-6 link block py-4 cursor-pointer border-b dark:border-b-slate-50/[0.06] border-b-slate-300"
         @click="$emit('close')"
       >
         <span>{{ $t(text as string) }}</span>
@@ -48,14 +48,6 @@ const smallerThanLg = breakpoints.smaller('md')
 .menu {
   background: $bg-primary;
   transition: all 0.4s ease-in 0s;
-}
-
-.link {
-  border-bottom: 1px solid $bg-secondary;
-
-  &:last-child {
-    border-bottom: none;
-  }
 }
 
 .#{$dark-mode-class} {

--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
 import CtaComponent from '@/components/buttons/CtaComponent.vue'
-import CtaIcon from '@/components/buttons/CtaIcon.vue'
 
 interface Link {
   id: string
@@ -23,37 +22,25 @@ defineEmits<{
 }>()
 
 const breakpoints = useBreakpoints(breakpointsTailwind)
-const smallerThanLg = breakpoints.smaller('lg')
+const smallerThanLg = breakpoints.smaller('md')
 </script>
 
 <template>
   <transition name="slide">
-    <div v-if="show && smallerThanLg" class="menu w-full fixed left-0 h-screen z-4">
-      <div class="flex items-center justify-between p-4">
-        <CtaComponent
-          data-test="mobile-homepage-link"
-          :to="{ name: 'Home' }"
-          @click="$emit('close')"
-        >
-          <img alt="SH logo" width="36" src="@/assets/sh-logo-small.png">
-        </CtaComponent>
-        <CtaIcon icon="fas fa-hamburger" @click="$emit('close')" />
-      </div>
-      <nav class="text-center">
-        <CtaComponent
-          v-for="{ id, href, to, text, test, target } in links"
-          :key="id"
-          class="link block py-4 head-6"
-          :data-test="`data-${test}`"
-          :to="to ? { name: to } : null"
-          :href="href"
-          :target="target ? target : null"
-          @click="$emit('close')"
-        >
-          <span>{{ $t(text as string) }}</span>
-        </CtaComponent>
-      </nav>
-    </div>
+    <nav v-if="show && smallerThanLg" class="menu">
+      <CtaComponent
+        v-for="{ id, href, to, text, test, target } in links"
+        :key="id"
+        :data-test="`data-${test}`"
+        :href="href"
+        :target="target ? target : null"
+        :to="to ? { name: to } : null"
+        class="head-6 link block py-4 cursor-pointer"
+        @click="$emit('close')"
+      >
+        <span>{{ $t(text as string) }}</span>
+      </CtaComponent>
+    </nav>
   </transition>
 </template>
 
@@ -79,14 +66,12 @@ const smallerThanLg = breakpoints.smaller('lg')
 
 .slide-enter-active,
 .slide-leave-active {
-  bottom: 0;
-  opacity: 1;
-  transition: bottom 0.25s ease-out 0, opacity 0.3s ease-in-out 0;
+  transition: 0.25s ease-out 0s;
 }
 
 .slide-enter-from,
 .slide-leave-to {
-  bottom: 100vh;
   opacity: 0;
+  transform: translateY(-100%);
 }
 </style>

--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -1,7 +1,20 @@
 <script setup lang="ts">
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
+import CtaComponent from '@/components/buttons/CtaComponent.vue'
+import CtaIcon from '@/components/buttons/CtaIcon.vue'
+
+interface Link {
+  id: string
+  to?: string
+  test?: string
+  text?: string
+  href?: string
+  target?: string
+  icon?: string
+}
 
 defineProps<{
+  links: Link[]
   show: boolean
 }>()
 
@@ -15,58 +28,30 @@ const smallerThanLg = breakpoints.smaller('lg')
 
 <template>
   <transition name="slide">
-    <div v-if="show && smallerThanLg" class="mobile-menu-container">
-      <div class="mobile-menu-header">
-        <div class="logo">
-          <router-link
-            data-test="mobile-homepage-link"
-            :to="{ name: 'Home' }"
-            @click="$emit('close')"
-          >
-            <img alt="SH logo" width="36" src="@/assets/sh-logo-small.png">
-          </router-link>
-        </div>
-        <button class="close-header" data-test="mobile-burger-menu-cta" @click="$emit('close')">
-          <i class="fas fa-hamburger" />
-        </button>
+    <div v-if="show && smallerThanLg" class="menu w-full fixed left-0 h-screen z-4">
+      <div class="flex items-center justify-between p-4">
+        <CtaComponent
+          data-test="mobile-homepage-link"
+          :to="{ name: 'Home' }"
+          @click="$emit('close')"
+        >
+          <img alt="SH logo" width="36" src="@/assets/sh-logo-small.png">
+        </CtaComponent>
+        <CtaIcon icon="fas fa-hamburger" @click="$emit('close')" />
       </div>
-      <nav>
-        <div class="navbar" data-test="mobile-nav-link-wrapper">
-          <a
-            data-test="mobile-github-page-link"
-            href="https://github.com/Schrodinger-Hat"
-            target="_blank"
-            @click="$emit('close')"
-          >GitHub
-          </a>
-          <router-link
-            data-test="mobile-team-page-link"
-            :to="{ name: 'Team' }"
-            @click="$emit('close')"
-          >
-            {{ $t('navbar.team') }}
-          </router-link>
-          <router-link
-            data-test="mobile-event-page-link"
-            :to="{ name: 'EventList' }"
-            @click="$emit('close')"
-          >
-            {{ $t('navbar.events') }}
-          </router-link>
-          <router-link
-            data-test="mobile-conduct-page-link"
-            :to="{ name: 'CodeOfConduct' }"
-            @click="$emit('close')"
-          >
-            {{ $t('navbar.codeOfConduct') }}
-          </router-link>
-          <a
-            data-test="mobile-go-nord-page-link"
-            href="https://ign.schrodinger-hat.it"
-            target="_blank"
-            @click="$emit('close')"
-          > ImageGoNord </a>
-        </div>
+      <nav class="text-center">
+        <CtaComponent
+          v-for="{ id, href, to, text, test, target } in links"
+          :key="id"
+          class="link block py-4 head-6"
+          :data-test="`data-${test}`"
+          :to="to ? { name: to } : null"
+          :href="href"
+          :target="target ? target : null"
+          @click="$emit('close')"
+        >
+          <span>{{ $t(text as string) }}</span>
+        </CtaComponent>
       </nav>
     </div>
   </transition>
@@ -74,20 +59,20 @@ const smallerThanLg = breakpoints.smaller('lg')
 
 <style scoped lang="scss">
 .menu {
-  background-color: $bg-primary;
-  transition: all 0.4s ease-in 0;
+  background: $bg-primary;
+  transition: all 0.4s ease-in 0s;
 }
 
-li {
+.link {
   border-bottom: 1px solid $bg-secondary;
 
-  &:first-of-type{
-    border-top: 1px solid $bg-secondary;
+  &:last-child {
+    border-bottom: none;
   }
 }
 
 .#{$dark-mode-class} {
-  .menu {
+  .menu{
     background: $dark-bg-primary;
   }
 }

--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -23,17 +23,17 @@ const emit = defineEmits<{
 }>()
 
 const breakpoints = useBreakpoints(breakpointsTailwind)
-const smallerThanLg = breakpoints.smaller('md')
+const smallerThanMd = breakpoints.smaller('md')
 
-watch(smallerThanLg, (newIsSmaller) => {
-  if (props.show && newIsSmaller)
+watch(smallerThanMd, (value) => {
+  if (props.show && !value)
     emit('close')
 })
 </script>
 
 <template>
   <transition name="slide">
-    <nav v-if="show && smallerThanLg" class="menu">
+    <nav v-if="show && smallerThanMd" class="menu">
       <CtaComponent
         v-for="{ id, href, to, text, test, target } in links"
         :key="id"
@@ -41,7 +41,7 @@ watch(smallerThanLg, (newIsSmaller) => {
         :href="href"
         :target="target ? target : null"
         :to="to ? { name: to } : null"
-        class="head-6 link block py-4 cursor-pointer border-b dark:border-b-slate-50/[0.06] border-b-slate-300"
+        class="head-6 link block py-4 cursor-pointer border-b border-b-slate-300 dark:border-b-slate-50/[0.06] "
         @click="$emit('close')"
       >
         <span>{{ $t(text as string) }}</span>

--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -1,88 +1,72 @@
 <script setup lang="ts">
-const props = defineProps<{
-  showMobileMenu: boolean
-  smallerThanLg: boolean
+import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
+
+defineProps<{
+  show: boolean
 }>()
 
 defineEmits<{
-  (e: 'onCloseMenu'): void
+  (e: 'close'): void
 }>()
 
-const links = [
-  {
-    id: 'Team',
-    test: 'team-link',
-    text: 'navbar.team',
-    to: 'Team',
-  },
-  {
-    id: 'Events',
-    test: 'events-link',
-    text: 'navbar.events',
-    to: 'EventList',
-  },
-  {
-    id: 'CodeOfConduct',
-    test: 'conduct-link',
-    text: 'navbar.codeOfConduct',
-    to: 'CodeOfConduct',
-  },
-  {
-    href: 'https://github.com/Schrodinger-Hat',
-    id: 'Github',
-    test: 'github-link',
-    text: 'GitHub',
-  },
-  {
-    href: 'https://ign.schrodinger-hat.it',
-    id: 'IGN',
-    test: 'ign-link',
-    text: 'ImageGoNord',
-  },
-]
+const breakpoints = useBreakpoints(breakpointsTailwind)
+const smallerThanLg = breakpoints.smaller('lg')
 </script>
 
 <template>
   <transition name="slide">
-    <div
-      v-if="props.showMobileMenu && props.smallerThanLg"
-      class="menu w-full h-[calc(100vh)] fixed left-0 z-1"
-    >
-      <div class="flex justify-between items-center p-4">
-        <RouterLink
-          data-test="mobile-homepage-link"
-          :to="{ name: 'Home' }"
-          @click="$emit('onCloseMenu')"
-        >
-          <img alt="SH logo" width="36" src="@/assets/sh-logo-small.png">
-        </RouterLink>
-        <button
-          class="my-2 border-none rounded-1 cursor-pointer"
-          data-test="mobile-burger-menu-cta"
-          @click="$emit('onCloseMenu')"
-        >
+    <div v-if="show && smallerThanLg" class="mobile-menu-container">
+      <div class="mobile-menu-header">
+        <div class="logo">
+          <router-link
+            data-test="mobile-homepage-link"
+            :to="{ name: 'Home' }"
+            @click="$emit('close')"
+          >
+            <img alt="SH logo" width="36" src="@/assets/sh-logo-small.png">
+          </router-link>
+        </div>
+        <button class="close-header" data-test="mobile-burger-menu-cta" @click="$emit('close')">
           <i class="fas fa-hamburger" />
         </button>
       </div>
-      <nav class="text-center">
-        <ul>
-          <li
-            v-for="{ href, text, to, id, test } in links"
-            :key="id"
-            class="py-4 text-xl"
+      <nav>
+        <div class="navbar" data-test="mobile-nav-link-wrapper">
+          <a
+            data-test="mobile-github-page-link"
+            href="https://github.com/Schrodinger-Hat"
+            target="_blank"
+            @click="$emit('close')"
+          >GitHub
+          </a>
+          <router-link
+            data-test="mobile-team-page-link"
+            :to="{ name: 'Team' }"
+            @click="$emit('close')"
           >
-            <a
-              v-if="href" :href="href"
-              :data-test="`mobile-${test}`"
-              @click="$emit('onCloseMenu')"
-            >
-              {{ text }}
-            </a>
-            <RouterLink v-else :to="{ name: to }">
-              {{ $t(text) }}
-            </RouterLink>
-          </li>
-        </ul>
+            {{ $t('navbar.team') }}
+          </router-link>
+          <router-link
+            data-test="mobile-event-page-link"
+            :to="{ name: 'EventList' }"
+            @click="$emit('close')"
+          >
+            {{ $t('navbar.events') }}
+          </router-link>
+          <router-link
+            data-test="mobile-conduct-page-link"
+            :to="{ name: 'CodeOfConduct' }"
+            @click="$emit('close')"
+          >
+            {{ $t('navbar.codeOfConduct') }}
+          </router-link>
+          <a
+            data-test="mobile-go-nord-page-link"
+            href="https://ign.schrodinger-hat.it"
+            target="_blank"
+            @click="$emit('close')"
+          > ImageGoNord </a>
+        </div>
       </nav>
     </div>
   </transition>

--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -4,100 +4,106 @@ const props = defineProps<{
   smallerThanLg: boolean
 }>()
 
-const emit = defineEmits<{
+defineEmits<{
   (e: 'onCloseMenu'): void
 }>()
+
+const links = [
+  {
+    id: 'Team',
+    test: 'team-link',
+    text: 'navbar.team',
+    to: 'Team',
+  },
+  {
+    id: 'Events',
+    test: 'events-link',
+    text: 'navbar.events',
+    to: 'EventList',
+  },
+  {
+    id: 'CodeOfConduct',
+    test: 'conduct-link',
+    text: 'navbar.codeOfConduct',
+    to: 'CodeOfConduct',
+  },
+  {
+    href: 'https://github.com/Schrodinger-Hat',
+    id: 'Github',
+    test: 'github-link',
+    text: 'GitHub',
+  },
+  {
+    href: 'https://ign.schrodinger-hat.it',
+    id: 'IGN',
+    test: 'ign-link',
+    text: 'ImageGoNord',
+  },
+]
 </script>
 
 <template>
   <transition name="slide">
-    <div v-if="props.showMobileMenu && props.smallerThanLg" class="mobile-menu-container">
-      <div class="mobile-menu-header">
-        <div class="logo">
-          <router-link
-            data-test="mobile-homepage-link"
-            :to="{ name: 'Home' }"
-            @click="emit('onCloseMenu')"
-          >
-            <img alt="SH logo" width="36" src="@/assets/sh-logo-small.png">
-          </router-link>
-        </div>
-        <button class="close-header" data-test="mobile-burger-menu-cta" @click="emit('onCloseMenu')">
+    <div
+      v-if="props.showMobileMenu && props.smallerThanLg"
+      class="menu w-full h-[calc(100vh)] fixed left-0 z-1"
+    >
+      <div class="flex justify-between items-center p-4">
+        <RouterLink
+          data-test="mobile-homepage-link"
+          :to="{ name: 'Home' }"
+          @click="$emit('onCloseMenu')"
+        >
+          <img alt="SH logo" width="36" src="@/assets/sh-logo-small.png">
+        </RouterLink>
+        <button
+          class="my-2 border-none rounded-1 cursor-pointer"
+          data-test="mobile-burger-menu-cta"
+          @click="$emit('onCloseMenu')"
+        >
           <i class="fas fa-hamburger" />
         </button>
       </div>
-      <nav>
-        <div class="navbar" data-test="mobile-nav-link-wrapper">
-          <a
-            data-test="mobile-github-page-link"
-            href="https://github.com/Schrodinger-Hat"
-            target="_blank"
-            @click="emit('onCloseMenu')"
-          >GitHub
-          </a>
-          <router-link
-            data-test="mobile-team-page-link"
-            :to="{ name: 'Team' }"
-            @click="emit('onCloseMenu')"
+      <nav class="text-center">
+        <ul>
+          <li
+            v-for="{ href, text, to, id, test } in links"
+            :key="id"
+            class="py-4 text-xl"
           >
-            {{ $t('navbar.team') }}
-          </router-link>
-          <router-link
-            data-test="mobile-event-page-link"
-            :to="{ name: 'EventList' }"
-            @click="emit('onCloseMenu')"
-          >
-            {{ $t('navbar.events') }}
-          </router-link>
-          <router-link
-            data-test="mobile-conduct-page-link"
-            :to="{ name: 'CodeOfConduct' }"
-            @click="emit('onCloseMenu')"
-          >
-            {{ $t('navbar.codeOfConduct') }}
-          </router-link>
-          <a
-            data-test="mobile-go-nord-page-link"
-            href="https://ign.schrodinger-hat.it"
-            target="_blank"
-            @click="emit('onCloseMenu')"
-          > ImageGoNord </a>
-        </div>
+            <a
+              v-if="href" :href="href"
+              :data-test="`mobile-${test}`"
+              @click="$emit('onCloseMenu')"
+            >
+              {{ text }}
+            </a>
+            <RouterLink v-else :to="{ name: to }">
+              {{ $t(text) }}
+            </RouterLink>
+          </li>
+        </ul>
       </nav>
     </div>
   </transition>
 </template>
 
 <style scoped lang="scss">
-.mobile-menu-container {
-  position: fixed;
-  z-index: 1;
-  left: 0;
-  width: 100%;
-  height: calc(100vh);
-  background: $bg-primary;
-  transition: all 0.4s ease-in 0s;
+.menu {
+  background-color: $bg-primary;
+  transition: all 0.4s ease-in 0;
+}
 
-  nav {
-    .navbar {
-      text-align: center;
+li {
+  border-bottom: 1px solid $bg-secondary;
 
-      a {
-        display: block;
-        padding: 0.8em 0;
-        border-bottom: 1px solid $bg-secondary;
-        font-size: 1.3em;
-
-        &:last-child {
-          border-bottom: none;
-        }
-      }
-    }
+  &:first-of-type{
+    border-top: 1px solid $bg-secondary;
   }
 }
 
 .#{$dark-mode-class} {
-  .mobile-menu-container {
+  .menu {
     background: $dark-bg-primary;
   }
 }
@@ -106,33 +112,12 @@ const emit = defineEmits<{
 .slide-leave-active {
   bottom: 0;
   opacity: 1;
-  transition: bottom 0.25s ease-out 0s, opacity 0.3s ease-in-out 0s;
+  transition: bottom 0.25s ease-out 0, opacity 0.3s ease-in-out 0;
 }
 
 .slide-enter-from,
 .slide-leave-to {
   bottom: 100vh;
   opacity: 0;
-}
-
-.mobile-menu-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 1rem;
-}
-
-button {
-  border: none;
-  border-radius: 0.25em;
-  margin: 0 0.4em;
-  background-color: transparent;
-  cursor: pointer;
-  font-size: 1.2em;
-  transition: background-color 100ms ease-in-out 0s;
-
-  &:hover {
-    background-color: $bg-secondary;
-  }
 }
 </style>

--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 const props = defineProps<{
-  showMobileMenu: Boolean
-  smallerThanLg: Boolean
+  showMobileMenu: boolean
+  smallerThanLg: boolean
 }>()
 
 const emit = defineEmits<{

--- a/src/components/layout/TheNavbar.vue
+++ b/src/components/layout/TheNavbar.vue
@@ -1,13 +1,10 @@
 <script setup lang='ts'>
 import { computed } from 'vue'
-import { breakpointsTailwind, useBreakpoints, useDark, useToggle } from '@vueuse/core'
+import { useDark, useToggle } from '@vueuse/core'
 import LogoAnimated from '@/components/buttons/LogoAnimated.vue'
 import MobileMenu from '@/components/layout/MobileMenu.vue'
 import CtaComponent from '@/components/buttons/CtaComponent.vue'
 import CtaIcon from '@/components/buttons/CtaIcon.vue'
-
-// TODO: Move this data to an outer file
-// TODO: Modify
 
 const links = [
   {
@@ -43,10 +40,8 @@ const githubCTA = {
   icon: 'fab fa-github',
 }
 
-const [showMobileMenu, toggleMobileMenu] = useToggle()
-const breakpoints = useBreakpoints(breakpointsTailwind)
+const [showMenu, toggleMenu] = useToggle()
 const isDark = useDark()
-const smallerThanLg = breakpoints.smaller('lg')
 const toggleDark = useToggle(isDark)
 
 const themeIcon = computed(() => isDark.value ? 'fa-sun' : 'fa-moon')
@@ -78,7 +73,7 @@ const themeIcon = computed(() => isDark.value ? 'fa-sun' : 'fa-moon')
           class="md:hidden"
           data-test="nav-burger-menu-cta"
           icon="fas fa-hamburger"
-          @click="toggleMobileMenu()"
+          @click="toggleMenu()"
         />
         <CtaIcon
           :icon="`fas ${themeIcon}`"
@@ -88,10 +83,9 @@ const themeIcon = computed(() => isDark.value ? 'fa-sun' : 'fa-moon')
       </nav>
     </div>
     <MobileMenu
-      :show-mobile-menu="showMobileMenu"
-      :smaller-than-lg="smallerThanLg"
+      :show="showMenu"
       data-test="mobile-menu"
-      @on-close-menu="toggleMobileMenu()"
+      @close="toggleMenu()"
     />
   </header>
 </template>

--- a/src/components/layout/TheNavbar.vue
+++ b/src/components/layout/TheNavbar.vue
@@ -6,6 +6,16 @@ import MobileMenu from '@/components/layout/MobileMenu.vue'
 import CtaComponent from '@/components/buttons/CtaComponent.vue'
 import CtaIcon from '@/components/buttons/CtaIcon.vue'
 
+interface Link {
+  id: string
+  to?: string
+  test?: string
+  text?: string
+  href?: string
+  target?: string
+  icon?: string
+}
+
 const links = [
   {
     id: 'Team',
@@ -34,10 +44,12 @@ const links = [
   },
 ]
 
-const githubCTA = {
-  test: 'github-cta',
-  link: 'https://github.com/Schrodinger-Hat',
+const ghCTA = {
+  href: 'https://github.com/Schrodinger-Hat',
   icon: 'fab fa-github',
+  id: 'GitHub',
+  test: 'github-cta',
+  text: 'GitHub',
 }
 
 const [showMenu, toggleMenu] = useToggle()
@@ -45,6 +57,7 @@ const isDark = useDark()
 const toggleDark = useToggle(isDark)
 
 const themeIcon = computed(() => isDark.value ? 'fa-sun' : 'fa-moon')
+const mobileLinks: Link[] = [ghCTA, ...links]
 </script>
 
 <template>
@@ -64,9 +77,9 @@ const themeIcon = computed(() => isDark.value ? 'fa-sun' : 'fa-moon')
           <span>{{ $t(text as string) }}</span>
         </CtaComponent>
         <CtaIcon
-          :data-test="githubCTA.test"
-          :href="githubCTA.link"
-          :icon="githubCTA.icon"
+          :data-test="ghCTA.test"
+          :href="ghCTA.href"
+          :icon="ghCTA.icon"
           target="_blank"
         />
         <CtaIcon
@@ -83,6 +96,7 @@ const themeIcon = computed(() => isDark.value ? 'fa-sun' : 'fa-moon')
       </nav>
     </div>
     <MobileMenu
+      :links="mobileLinks"
       :show="showMenu"
       data-test="mobile-menu"
       @close="toggleMenu()"

--- a/src/components/layout/TheNavbar.vue
+++ b/src/components/layout/TheNavbar.vue
@@ -4,10 +4,10 @@ import { breakpointsTailwind, useBreakpoints, useDark, useToggle } from '@vueuse
 import LogoAnimated from '@/components/buttons/LogoAnimated.vue'
 import MobileMenu from '@/components/layout/MobileMenu.vue'
 import CtaComponent from '@/components/buttons/CtaComponent.vue'
+import CtaIcon from '@/components/buttons/CtaIcon.vue'
 
-// TODO: Throw the buttons inside the CtaComponent
 // TODO: Move this data to an outer file
-// TODO: We could create a component called CtaIcon based of CtaComponent
+// TODO: Modify
 
 const links = [
   {
@@ -24,30 +24,24 @@ const links = [
   },
   {
     id: 'CodeOfConduct',
-    to: 'CodeOfConduct',
     test: 'code-page-link',
     text: 'navbar.codeOfConduct',
+    to: 'CodeOfConduct',
   },
   {
-    id: 'IGN',
     href: 'https://ign.schrodinger-hat.it',
+    id: 'IGN',
+    target: '_blank',
     test: 'IGN-link',
-    target: '_blank',
     text: 'ImageGoNord',
-    icon: null,
-  },
-  {
-    id: 'GitHub',
-    href: 'https://github.com/Schrodinger-Hat',
-    test: 'github-link',
-    target: '_blank',
-    text: null,
-    icon: {
-      class: 'fab fa-github',
-      test: 'nav-github-icon',
-    },
   },
 ]
+
+const githubCTA = {
+  test: 'github-cta',
+  link: 'https://github.com/Schrodinger-Hat',
+  icon: 'fab fa-github',
+}
 
 const [showMobileMenu, toggleMobileMenu] = useToggle()
 const breakpoints = useBreakpoints(breakpointsTailwind)
@@ -59,139 +53,64 @@ const themeIcon = computed(() => isDark.value ? 'fa-sun' : 'fa-moon')
 </script>
 
 <template>
-  <header class="container">
+  <header class="container flex h-20 m-auto p-none z-2">
     <div class="inner-header-container flex justify-between items-center w-full mx-auto px-4 md:px-0" data-test="nav-wrapper">
       <LogoAnimated />
-      <nav>
-        <div class="navbar" data-test="nav-link-wrapper">
-          <CtaComponent
-            v-for="{ href, icon, id, target, test, text, to } in links"
-            :key="id"
-            :data-test="`data-${test}`"
-            :to="{ name: to }"
-            :href="href"
-            :target="target ? target : null"
-            class="mx-1 p-1 rounded-1 cursor-pointer text-xl md:inline"
-            :class="[{ rounded: icon, hidden: !icon }]"
-          >
-            <i v-if="icon" :class="icon.class" :data-test="icon.test" />
-            <span v-else>{{ $t(text as string) }}</span>
-          </CtaComponent>
-          <button
-            class="hamburger-none-md"
-            data-test="nav-burger-menu-cta"
-            @click="toggleMobileMenu()"
-          >
-            <i class="fas fa-hamburger" data-test="nav-hamburget-icon" />
-          </button>
-          <button
-            data-test="nav-theme-cta"
-            @click="toggleDark()"
-          >
-            <i class="fas" :class="themeIcon" data-test="nav-theme-icon" />
-          </button>
-        </div>
+      <nav class="flex">
+        <CtaComponent
+          v-for="{ id, href, to, text, test, target } in links"
+          :key="id"
+          :data-test="`data-${test}`"
+          :to="to ? { name: to } : null"
+          :href="href"
+          :target="target ? target : null"
+          class="hidden mx-1 p-1 rounded-1 cursor-pointer text-xl md:inline"
+        >
+          <span>{{ $t(text as string) }}</span>
+        </CtaComponent>
+        <CtaIcon
+          :data-test="githubCTA.test"
+          :href="githubCTA.link"
+          :icon="githubCTA.icon"
+          target="_blank"
+        />
+        <CtaIcon
+          class="md:hidden"
+          data-test="nav-burger-menu-cta"
+          icon="fas fa-hamburger"
+          @click="toggleMobileMenu()"
+        />
+        <CtaIcon
+          :icon="`fas ${themeIcon}`"
+          data-test="nav-theme-icon"
+          @click="toggleDark()"
+        />
       </nav>
     </div>
     <MobileMenu
-      data-test="mobile-menu"
       :show-mobile-menu="showMobileMenu"
       :smaller-than-lg="smallerThanLg"
+      data-test="mobile-menu"
       @on-close-menu="toggleMobileMenu()"
     />
   </header>
 </template>
 
 <style scoped lang="scss">
-header {
-  position: relative;
-  z-index: $z-header;
-  display: flex;
-  height: 5em;
-  padding: 0 !important;
-  margin: auto;
-  text-align: left;
+a:not(.logo),
+button {
+  transition: background-color 0.1s ease-in-out;
 
-    nav {
-      display: flex;
-
-      .navbar {
-        a {
-          transition: background-color 100ms ease-in-out 0s;
-
-          &:hover {
-            background-color: $bg-secondary;
-          }
-        }
-
-        button {
-          border: none;
-          border-radius: 0.25em;
-          margin: 0 0.4em;
-          background-color: transparent;
-          cursor: pointer;
-          font-size: 1.2em;
-          transition: background-color 100ms ease-in-out 0s;
-
-          &:nth-child(-n + 3) {
-            display: none;
-          }
-
-          &:hover {
-            background-color: $bg-secondary;
-          }
-        }
-      }
-    }
-  }
-
-@media (width >= 56.25em) {
-  header {
-      .logo {
-        span {
-          font-size: 2em;
-        }
-      }
-
-      nav {
-        .navbar {
-          .hamburger-none-md {
-            display: none;
-          }
-
-          a {
-            &:nth-child(-n + 3) {
-              display: inline;
-            }
-          }
-        }
-      }
-    }
-  }
-
-@media (width <= 900px) {
-  .logo span {
-    pointer-events: none;
-  }
-
-  #gonord {
-    display: none;
+  &:hover {
+    background-color: $bg-secondary;
   }
 }
 
 .#{$dark-mode-class} {
-  header {
-    .inner-header-container {
-      nav {
-        .navbar {
-          a,
-          button {
-            &:hover {
-              background-color: $dark-bg-secondary;
-            }
-          }
-        }
-      }
+  a:not(.logo),
+  button {
+    &:hover {
+      background-color: $dark-bg-secondary;
     }
   }
 }

--- a/src/components/layout/TheNavbar.vue
+++ b/src/components/layout/TheNavbar.vue
@@ -40,7 +40,7 @@ const links = [
     id: 'IGN',
     target: '_blank',
     test: 'IGN-link',
-    text: 'ImageGoNord',
+    text: 'navbar.imageGoNord',
   },
 ]
 
@@ -49,7 +49,7 @@ const ghCTA = {
   icon: 'fab fa-github',
   id: 'GitHub',
   test: 'github-cta',
-  text: 'GitHub',
+  text: 'navbar.gitHub',
 }
 
 const [showMenu, toggleMenu] = useToggle()

--- a/src/components/layout/TheNavbar.vue
+++ b/src/components/layout/TheNavbar.vue
@@ -61,8 +61,8 @@ const mobileLinks: Link[] = [ghCTA, ...links]
 </script>
 
 <template>
-  <header class="container flex h-20 m-auto p-none z-2">
-    <div class="inner-header-container flex justify-between items-center w-full mx-auto px-4 md:px-0" data-test="nav-wrapper">
+  <header class="inline-flex w-full h-18 m-auto py-4 px-2 z-2 sticky top-0 lg:px-4">
+    <div class="flex justify-between items-center w-full mx-auto px-4 md:px-0" data-test="nav-wrapper">
       <LogoAnimated />
       <nav class="flex">
         <CtaComponent
@@ -96,6 +96,7 @@ const mobileLinks: Link[] = [ghCTA, ...links]
       </nav>
     </div>
     <MobileMenu
+      class="w-full h-screen absolute top-18 left-0 text-center"
       :links="mobileLinks"
       :show="showMenu"
       data-test="mobile-menu"
@@ -105,6 +106,10 @@ const mobileLinks: Link[] = [ghCTA, ...links]
 </template>
 
 <style scoped lang="scss">
+header {
+ background: $bg-primary;
+}
+
 a:not(.logo),
 button {
   transition: background-color 0.1s ease-in-out;
@@ -115,6 +120,10 @@ button {
 }
 
 .#{$dark-mode-class} {
+  header {
+    background: $dark-bg-primary;
+  }
+
   a:not(.logo),
   button {
     &:hover {

--- a/src/components/layout/TheNavbar.vue
+++ b/src/components/layout/TheNavbar.vue
@@ -1,9 +1,10 @@
 <script setup lang='ts'>
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 import { useDark, useToggle } from '@vueuse/core'
 import LogoAnimated from '@/components/buttons/LogoAnimated.vue'
 import MobileMenu from '@/components/layout/MobileMenu.vue'
 import CtaComponent from '@/components/buttons/CtaComponent.vue'
+import { useLockScroll } from '@/functions/useLockScroll'
 import CtaIcon from '@/components/buttons/CtaIcon.vue'
 
 interface Link {
@@ -53,11 +54,14 @@ const ghCTA = {
 }
 
 const [showMenu, toggleMenu] = useToggle()
+const { scrollLock } = useLockScroll()
 const isDark = useDark()
+const mobileLinks: Link[] = [ghCTA, ...links]
 const toggleDark = useToggle(isDark)
 
 const themeIcon = computed(() => isDark.value ? 'fa-sun' : 'fa-moon')
-const mobileLinks: Link[] = [ghCTA, ...links]
+
+watch(showMenu, value => (value ? scrollLock.value = true : scrollLock.value = false))
 </script>
 
 <template>
@@ -96,7 +100,7 @@ const mobileLinks: Link[] = [ghCTA, ...links]
       </nav>
     </div>
     <MobileMenu
-      class="w-full h-screen absolute top-15 left-0 text-center"
+      class="w-full h-screen absolute top-15 left-0 overflow-auto text-center"
       :links="mobileLinks"
       :show="showMenu"
       data-test="mobile-menu"

--- a/src/components/layout/TheNavbar.vue
+++ b/src/components/layout/TheNavbar.vue
@@ -54,9 +54,7 @@ const isDark = useDark()
 const smallerThanLg = breakpoints.smaller('lg')
 const toggleDark = useToggle(isDark)
 
-const themeIcon = computed(() => {
-  return isDark.value ? 'fa-sun' : 'fa-moon'
-})
+const themeIcon = computed(() => isDark.value ? 'fa-sun' : 'fa-moon')
 </script>
 
 <template>

--- a/src/components/layout/TheNavbar.vue
+++ b/src/components/layout/TheNavbar.vue
@@ -8,44 +8,45 @@ import CtaComponent from '@/components/buttons/CtaComponent.vue'
 // TODO: Move this data to an outer file
 // TODO: We could create a component called CtaIcon based of CtaComponent
 
-const links = {
-  router: [
-    {
-      name: 'Team',
-      test: 'nav-team-page-link',
-      text: 'navbar.team',
+const links = [
+  {
+    id: 'Team',
+    to: 'Team',
+    test: 'team-page-link',
+    text: 'navbar.team',
+  },
+  {
+    id: 'Events',
+    to: 'EventList',
+    test: 'event-page-link',
+    text: 'navbar.events',
+  },
+  {
+    id: 'CodeOfConduct',
+    to: 'CodeOfConduct',
+    test: 'code-page-link',
+    text: 'navbar.codeOfConduct',
+  },
+  {
+    id: 'IGN',
+    href: 'https://ign.schrodinger-hat.it',
+    test: 'IGN-link',
+    target: '_blank',
+    text: 'ImageGoNord',
+    icon: null,
+  },
+  {
+    id: 'GitHub',
+    href: 'https://github.com/Schrodinger-Hat',
+    test: 'github-link',
+    target: '_blank',
+    text: null,
+    icon: {
+      class: 'fab fa-github',
+      test: 'nav-github-icon',
     },
-    {
-      name: 'EventList',
-      test: 'nav-team-page-link',
-      text: 'navbar.events',
-    },
-    {
-      name: 'CodeOfConduct',
-      test: 'nav-team-page-link',
-      text: 'navbar.codeOfConduct',
-    },
-  ],
-  anchors: [
-    {
-      id: 'gonord',
-      href: 'https://ign.schrodinger-hat.it',
-      test: 'nav-go-nord-page-link',
-      text: 'ImageGoNord',
-      icon: null,
-    },
-    {
-      id: 'github',
-      href: 'https://github.com/Schrodinger-Hat',
-      test: 'nav-github-page-link',
-      text: null,
-      icon: {
-        class: 'fab fa-github',
-        test: 'nav-github-icon',
-      },
-    },
-  ],
-}
+  },
+]
 
 const [showMobileMenu, toggleMobileMenu] = useToggle()
 const breakpoints = useBreakpoints(breakpointsTailwind)
@@ -65,21 +66,27 @@ const themeIcon = computed(() => {
       <nav>
         <div class="navbar" data-test="nav-link-wrapper">
           <CtaComponent
-            v-for="{ test, text, name } in links.router"
-            :key="text"
-            :to="{ name }"
-            :data-test="test"
+            v-for="{ href, icon, id, target, test, text, to } in links"
+            :key="id"
+            :data-test="`data-${test}`"
+            :to="{ name: to }"
+            :href="href"
+            :target="target ? target : null"
           >
-            {{ $t(text) }}
-          </CtaComponent>
-          <CtaComponent v-for="{ id, href, test, text, icon } in links.anchors" :id="id" :key="id" :href="href" :data-test="test">
             <i v-if="icon" :class="icon.class" :data-test="icon.test" />
-            <span v-else>{{ text }}</span>
+            <span v-else>{{ $t(text as string) }}</span>
           </CtaComponent>
-          <button class="hamburger-none-md" data-test="nav-burger-menu-cta" @click="toggleMobileMenu()">
+          <button
+            class="hamburger-none-md"
+            data-test="nav-burger-menu-cta"
+            @click="toggleMobileMenu()"
+          >
             <i class="fas fa-hamburger" data-test="nav-hamburget-icon" />
           </button>
-          <button data-test="nav-theme-cta" @click="toggleDark()">
+          <button
+            data-test="nav-theme-cta"
+            @click="toggleDark()"
+          >
             <i class="fas" :class="themeIcon" data-test="nav-theme-icon" />
           </button>
         </div>

--- a/src/components/layout/TheNavbar.vue
+++ b/src/components/layout/TheNavbar.vue
@@ -4,7 +4,7 @@ import { useDark, useToggle } from '@vueuse/core'
 import LogoAnimated from '@/components/buttons/LogoAnimated.vue'
 import MobileMenu from '@/components/layout/MobileMenu.vue'
 import CtaComponent from '@/components/buttons/CtaComponent.vue'
-import { useLockScroll } from '@/functions/useLockScroll'
+import { useGlobalScrollLock } from '@/functions/useGlobalScrollLock'
 import CtaIcon from '@/components/buttons/CtaIcon.vue'
 
 interface Link {
@@ -54,7 +54,7 @@ const ghCTA = {
 }
 
 const [showMenu, toggleMenu] = useToggle()
-const { scrollLock } = useLockScroll()
+const scrollLock = useGlobalScrollLock()
 const isDark = useDark()
 const mobileLinks: Link[] = [ghCTA, ...links]
 const toggleDark = useToggle(isDark)

--- a/src/components/layout/TheNavbar.vue
+++ b/src/components/layout/TheNavbar.vue
@@ -5,6 +5,7 @@ import LogoAnimated from '@/components/buttons/LogoAnimated.vue'
 import MobileMenu from '@/components/layout/MobileMenu.vue'
 import CtaComponent from '@/components/buttons/CtaComponent.vue'
 
+// TODO: Throw the buttons inside the CtaComponent
 // TODO: Move this data to an outer file
 // TODO: We could create a component called CtaIcon based of CtaComponent
 
@@ -70,6 +71,8 @@ const themeIcon = computed(() => isDark.value ? 'fa-sun' : 'fa-moon')
             :to="{ name: to }"
             :href="href"
             :target="target ? target : null"
+            class="mx-1 p-1 rounded-1 cursor-pointer text-xl md:inline"
+            :class="[{ rounded: icon, hidden: !icon }]"
           >
             <i v-if="icon" :class="icon.class" :data-test="icon.test" />
             <span v-else>{{ $t(text as string) }}</span>
@@ -123,20 +126,8 @@ header {
       display: flex;
 
       .navbar {
-        justify-content: space-between;
-        -webkit-box-pack: justify;
-        list-style: none;
-
         a {
-          border-radius: 0.25em;
-          margin: 0 0.4em;
-          cursor: pointer;
-          font-size: 1.2em;
           transition: background-color 100ms ease-in-out 0s;
-
-          &:nth-child(-n + 3) {
-            display: none;
-          }
 
           &:hover {
             background-color: $bg-secondary;

--- a/src/components/layout/TheNavbar.vue
+++ b/src/components/layout/TheNavbar.vue
@@ -61,7 +61,7 @@ const mobileLinks: Link[] = [ghCTA, ...links]
 </script>
 
 <template>
-  <header class="inline-flex w-full h-18 m-auto py-4 px-2 z-2 sticky top-0 lg:px-4">
+  <header class="inline-flex w-full h-15 m-auto py-4 px-2 sticky top-0 z-2 backdrop-blur border-b border-b-slate-300 lg:px-4 dark:border-slate-50/[0.06]" :class="{ 'active-menu': showMenu }">
     <div class="flex justify-between items-center w-full mx-auto px-4 md:px-0" data-test="nav-wrapper">
       <LogoAnimated />
       <nav class="flex">
@@ -96,7 +96,7 @@ const mobileLinks: Link[] = [ghCTA, ...links]
       </nav>
     </div>
     <MobileMenu
-      class="w-full h-screen absolute top-18 left-0 text-center"
+      class="w-full h-screen absolute top-15 left-0 text-center"
       :links="mobileLinks"
       :show="showMenu"
       data-test="mobile-menu"
@@ -107,7 +107,11 @@ const mobileLinks: Link[] = [ghCTA, ...links]
 
 <style scoped lang="scss">
 header {
- background: $bg-primary;
+ background: $bg-primary-reduced;
+
+ &.active-menu {
+  background: $bg-primary;
+ }
 }
 
 a:not(.logo),
@@ -121,7 +125,11 @@ button {
 
 .#{$dark-mode-class} {
   header {
-    background: $dark-bg-primary;
+    background: $dark-bg-primary-reduced;
+
+    &.active-menu {
+      background: $dark-bg-primary;
+    }
   }
 
   a:not(.logo),

--- a/src/components/layout/TheNavbar.vue
+++ b/src/components/layout/TheNavbar.vue
@@ -60,7 +60,7 @@ const themeIcon = computed(() => isDark.value ? 'fa-sun' : 'fa-moon')
 
 <template>
   <header class="container">
-    <div class="inner-header-container" data-test="nav-wrapper">
+    <div class="inner-header-container flex justify-between items-center w-full mx-auto px-4 md:px-0" data-test="nav-wrapper">
       <LogoAnimated />
       <nav>
         <div class="navbar" data-test="nav-link-wrapper">
@@ -112,16 +112,6 @@ header {
   margin: auto;
   text-align: left;
 
-  .inner-header-container {
-    display: flex;
-    width: 100%;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0 0.5em;
-    margin: 0 auto;
-    -webkit-box-align: center;
-    -webkit-box-pack: justify;
-
     nav {
       display: flex;
 
@@ -154,13 +144,9 @@ header {
       }
     }
   }
-}
 
 @media (width >= 56.25em) {
   header {
-    .inner-header-container {
-      padding: 0;
-
       .logo {
         span {
           font-size: 2em;
@@ -182,7 +168,6 @@ header {
       }
     }
   }
-}
 
 @media (width <= 900px) {
   .logo span {

--- a/src/functions/useCtaComponent.ts
+++ b/src/functions/useCtaComponent.ts
@@ -14,9 +14,9 @@ export const useCtaComponent = (attrs: MaybeRef<SetupContext['attrs']>): CtaComp
 
   const component = computed(() => {
     switch (true) {
-      case 'to' in attributes:
+      case ('to' in attributes && attributes.to !== undefined):
         return 'router-link'
-      case 'href' in attributes:
+      case ('href' in attributes && attributes.href !== undefined):
         return 'a'
       default:
         return 'button'

--- a/src/functions/useCtaComponent.ts
+++ b/src/functions/useCtaComponent.ts
@@ -1,20 +1,20 @@
-import type { ComputedRef, SetupContext } from 'vue'
+import type { SetupContext } from 'vue'
 import { computed, unref } from 'vue'
 import type { MaybeRef } from '@vueuse/core'
 
 type Component = 'a' | 'button' | 'router-link'
 
-interface CtaComponent {
-  component: ComputedRef<Component>
-  bindings: ComputedRef<SetupContext['attrs']>
+type Attributes = SetupContext['attrs'] & {
+  to?: { name: string }
+  href?: string
 }
 
-export const useCtaComponent = (attrs: MaybeRef<SetupContext['attrs']>): CtaComponent => {
+export const useCtaComponent = (attrs: MaybeRef<Attributes>) => {
   const attributes = unref(attrs)
 
-  const component = computed(() => {
+  const component = computed((): Component => {
     switch (true) {
-      case ('to' in attributes && attributes.to !== undefined):
+      case ('to' in attributes && attributes.to?.name !== undefined):
         return 'router-link'
       case ('href' in attributes && attributes.href !== undefined):
         return 'a'
@@ -23,7 +23,7 @@ export const useCtaComponent = (attrs: MaybeRef<SetupContext['attrs']>): CtaComp
     }
   })
 
-  const bindings = computed((): SetupContext['attrs'] => ({ ...attributes }))
+  const bindings = computed((): Attributes => ({ ...attributes }))
 
   return {
     bindings,

--- a/src/functions/useGlobalScrollLock.ts
+++ b/src/functions/useGlobalScrollLock.ts
@@ -1,0 +1,7 @@
+import { useScrollLock } from '@vueuse/core'
+
+const scrollLock = useScrollLock(document.documentElement)
+
+export const useGlobalScrollLock = () => {
+  return scrollLock
+}

--- a/src/functions/useLockScroll.ts
+++ b/src/functions/useLockScroll.ts
@@ -1,9 +1,0 @@
-import { useScrollLock } from '@vueuse/core'
-
-export const useLockScroll = () => {
-  const scrollLock = useScrollLock(document.documentElement)
-
-  return {
-    scrollLock,
-  }
-}

--- a/src/functions/useLockScroll.ts
+++ b/src/functions/useLockScroll.ts
@@ -1,0 +1,9 @@
+import { useScrollLock } from '@vueuse/core'
+
+export const useLockScroll = () => {
+  const scrollLock = useScrollLock(document.documentElement)
+
+  return {
+    scrollLock,
+  }
+}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -14,6 +14,8 @@ const messages = {
       team: 'Team',
       events: 'Eventi',
       codeOfConduct: 'Codice di Condotta',
+      imageGoNord: 'ImageGoNord',
+      gitHub: 'GitHub',
     },
     main: {
       h1: 'Una community open source italiana',
@@ -298,6 +300,8 @@ const messages = {
       team: 'Team',
       events: 'Events',
       codeOfConduct: 'Code of Conduct',
+      imageGoNord: 'ImageGoNord',
+      gitHub: 'GitHub',
     },
     main: {
       h1: 'An Italian open source community',

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -6,12 +6,14 @@ $dark-mode-class: 'dark';
 $z-header: 2;
 
 // Colors
-$text-primary: $nord3;
-$text-secondary: $nord6;
+$bg-primary-reduced: rgba(236, 239, 244, 0.65);
 $bg-primary: $nord6;
 $bg-secondary: $nord4;
+$text-primary: $nord3;
+$text-secondary: $nord6;
 
 // Dark-mode Colors
+$dark-bg-primary-reduced: rgba(46, 52, 64, 0.65);
 $dark-bg-primary: $nord0;
 $dark-bg-secondary: $nord1;
 $dark-bg-secondary: $nord3;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -6,14 +6,14 @@ $dark-mode-class: 'dark';
 $z-header: 2;
 
 // Colors
-$bg-primary-reduced: rgba(236, 239, 244, 0.65);
+$bg-primary-reduced: rgba(236, 239, 244, 0.7);
 $bg-primary: $nord6;
 $bg-secondary: $nord4;
 $text-primary: $nord3;
 $text-secondary: $nord6;
 
 // Dark-mode Colors
-$dark-bg-primary-reduced: rgba(46, 52, 64, 0.65);
+$dark-bg-primary-reduced: rgba(46, 52, 64, 0.7);
 $dark-bg-primary: $nord0;
 $dark-bg-secondary: $nord1;
 $dark-bg-secondary: $nord3;


### PR DESCRIPTION
## Description

- Update `MobileMenu` && `TheNavbar` to utilize UnoCSS when possible
- Reduce boilerplate in both above mentioned components by utilizing better template logic
- Create `CtaComponent` and `CtaIcon` components that will help us unify and utilize only two components for CTAs.
- Create `useGlobalScrollLock` function that blocks document scroll when the `MobileMenu` is shown.
- Add minimal lint and formatting to `App.vue`.
- Create `stylelint` script for NPM.
- Add a nice blurred and reduced opacity style to `TheNavbar` 😎 

Pushes forward #89

## Changes

**What kind of change does this PR introduce?** (check at least one by adding an "x" between the brackets)

- [ ] Bugfix
- [X] Feature
- [X] Code style update
- [X] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications: -

**The PR fulfills these requirements:**

- [X] Schrödinger Hat [code of conduct](https://www.schrodinger-hat.it/code-of-conduct)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)