### PR TITLE
fix(PageEvent): use fallback locale to access translations objects

### DIFF
--- a/src/pages/PageEvents.vue
+++ b/src/pages/PageEvents.vue
@@ -12,8 +12,9 @@ import type { Event } from '@i18n/events/index'
 
 const SESSIONS_LINK = 'https://github.com/Schrodinger-Hat/sh-sessions/issues/new/choose'
 
-const { t, locale } = useI18n()
-const events = computed(() => messages[locale.value as LanguageCodes].page.events.data)
+const { t, locale, fallbackLocale } = useI18n()
+
+const events = computed(() => messages[locale.value as LanguageCodes]?.page.events.data ?? messages[fallbackLocale.value as LanguageCodes].page.events.data)
 
 const filters = ref({
   category: undefined,


### PR DESCRIPTION
## Description

fix https://github.com/Schrodinger-Hat/schrodinger-hat-website/issues/106

**Summary**

Hello :wave: a computed is trying to use the locale to access to the translation object used by i18n. I18n don't fallback the locale so having any other languages other than `it` an `en` will break the page. 

## Changes


This PR simply fix by using the fallback locale as an accessor if the data cannot be found with the current locale.

It may be worth taking out data from i18n if it is not used as translations

**What kind of change does this PR introduce?** (check at least one by adding an "x" between the brackets)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [ ] Schrödinger Hat [code of conduct](https://www.schrodinger-hat.it/code-of-conduct)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

- Add any other context about the pull request here.
